### PR TITLE
React better to invalid link

### DIFF
--- a/scripts/shared/url_listener.js
+++ b/scripts/shared/url_listener.js
@@ -3,6 +3,7 @@ class UrlListener {
     #isActive;
     #fktTabEvent;
     #fktTabUpdateEvent;
+    #fktWindowChanged;
     #lastUrl = "";
     #hasFavIcon = false;
 
@@ -38,7 +39,12 @@ class UrlListener {
                 return;
             }
         }
-        this.activate();
+        this.#fktWindowChanged = (windowId) => {
+            if (windowId === -1) // No window selected
+                return;
+            this.retransmit();
+        }
+        this.deactivate();
     }
 
     #sendUrl(url, favIconUrl) {
@@ -61,6 +67,7 @@ class UrlListener {
             return;
         browser.tabs.onActivated.addListener(this.#fktTabEvent);
         browser.tabs.onUpdated.addListener(this.#fktTabUpdateEvent);
+        browser.windows.onFocusChanged.addListener(this.#fktWindowChanged);
         this.#isActive = true;
     }
     
@@ -69,9 +76,10 @@ class UrlListener {
             return;
         browser.tabs.onActivated.removeListener(this.#fktTabEvent);
         browser.tabs.onUpdated.removeListener(this.#fktTabUpdateEvent);
+        browser.windows.onFocusChanged.removeListener(this.#fktWindowChanged);
         this.#isActive = false;
     }
-    
+
     activate() {
         this.#connect();
         this.retransmit();

--- a/scripts/sidebar/sidebar.js
+++ b/scripts/sidebar/sidebar.js
@@ -6,9 +6,11 @@ import { SortControls } from "./reader_sort.js"
 import { ShowAllInterface } from "../shared/scheduler.js"
 import { CanvasIcon } from "./canvas_icon.js"
 import { TrackingState } from "../shared/tracking_state.js"
+import { dissectUrl } from "../shared/url.js"
 
 // Tab management
 let webReader;
+let addComicBtn
 let sortControls;
 let isSetUp = false;
 let trackingStateImage;
@@ -22,8 +24,8 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 
 function setUpUserInterface() {
-    const addComic = document.getElementById('add_reader');
-    addComic.onclick = function () {addCurrentPage()};
+    addComicBtn = document.getElementById('add_reader');
+    addComicBtn.onclick = function () {addCurrentPage()};
 
     setUpSearchBar();
     setUpDropdownMenu();
@@ -133,6 +135,16 @@ function addCurrentPage() {
             }, onError);
 }
 
+function updateAddButtonActivity(url) {
+    let test = dissectUrl(url);
+    if (test === undefined) {
+        // Link is reserved or no valid URL
+        addComicBtn.disabled = true;
+    } else {
+        addComicBtn.disabled = false;
+    }
+}
+
 // Display error for failed promises
 function onError(error) {
     console.log(`Error: ${error}`);
@@ -141,6 +153,7 @@ function onError(error) {
 async function updateBookmark(data) {
     if (webReader === undefined)
         return;
+    updateAddButtonActivity(data.url);
     await webReader.updateBookmark(data);
 }
 

--- a/sidebar/sidebar_panel.css
+++ b/sidebar/sidebar_panel.css
@@ -196,3 +196,7 @@
     color: black;
     background-color: var(--button-hover-color);
 }
+.add_reader:disabled {
+    color: grey;
+    background-color: lightgrey;
+}


### PR DESCRIPTION
* "Add Reader" button is now disabled on invalid/reserved URLs
* Even if you click the button from another window, the chain is also interupted further down
* Changing windows will now also retransmit the current URL to update display
* Fix: UrlListener will no longer start enabled but disabled. Background script initializes once active state is read from storage.