### PR TITLE
Storage update

### DIFF
--- a/scripts/shared/html_container.js
+++ b/scripts/shared/html_container.js
@@ -16,6 +16,7 @@ class HtmlContainer {
         // TODO: find implementation
         // Bonus: implement without deep knowledge, 
         //        keep implementation information out of this
+        return [];
     }
 
     #storeObjectUsingUrl(object, url) {

--- a/scripts/shared/html_container.js
+++ b/scripts/shared/html_container.js
@@ -5,21 +5,12 @@ class HtmlContainer {
     
     constructor() {}
 
-    saveObject(object) {
-        // Bonus: get getPrefixMasks() out of here
-        let urlList = object.getPrefixMasks();
+    saveObject(object, urlList) {
         let copyId = 1;
         for (let url of urlList) {
             this.#storeObjectUsingUrl(object, url, copyId);
             copyId += 1;
         }
-    }
-
-    findConflictsWith(newReaderData) {
-        // TODO: find implementation
-        // Bonus: implement without deep knowledge, 
-        //        keep implementation information out of this
-        return [];
     }
 
     #storeObjectUsingUrl(object, url, copyId) {
@@ -47,8 +38,13 @@ class HtmlContainer {
     }
 
     removeObject(urlList) {
-        // TODO: remove [] once it's actually a list
-        for (let url of [urlList]) {
+        // urlList can be single URL whitout list
+        if (!Array.isArray(urlList)) {
+            this.#removeObjectUsing(urlList);
+            return;
+        }
+        // otherwise treat each list member individually
+        for (let url of urlList) {
             this.#removeObjectUsing(url);
         }
     }
@@ -131,8 +127,10 @@ class HtmlContainer {
 }
 
 class StorageContainer {
+    // Encapsulates each cargo element
+    // Allows to keep track of copy counts
     #cargo;
-    #copyId;    // If it's > 1, it's an alias
+    #copyId;    // If it's > 1, it's an alias object
 
     constructor(cargo, copyId) {
         this.#cargo = cargo;
@@ -140,6 +138,8 @@ class StorageContainer {
     }
 
     respondsToIdentification(identification) {
+        // TODO: establish this call during init
+        //       -> get rid of implementation knowledge
         return this.#cargo.urlIsCompatible(identification);
     }
 

--- a/scripts/shared/html_container.js
+++ b/scripts/shared/html_container.js
@@ -12,6 +12,12 @@ class HtmlContainer {
         }
     }
 
+    findConflictsWith(newReaderData) {
+        // TODO: find implementation
+        // Bonus: implement without deep knowledge, 
+        //        keep implementation information out of this
+    }
+
     #storeObjectUsingUrl(object, url) {
         let host = getHost(url);
         if (host === undefined) {

--- a/scripts/shared/reader_manager.js
+++ b/scripts/shared/reader_manager.js
@@ -114,6 +114,19 @@ class CoreReaderManager extends BasicReaderManager {
         this._readerSync = ReaderSync.makeCore(intId, this);
     }
 
+    managesThis(readerData) {
+        return readerData === this._readerData;
+    }
+
+    canBeUpdatedWith(readerObjectLike) {
+        const tempReader = new ReaderData(readerObjectLike);
+        return this._parentInterface.canWeUpdateReaderWith(this._readerData, tempReader);
+    }
+
+    getRecognitionInterface() {
+        return this._readerData.getRecognitionInterface();
+    }
+
     saveProgress() {
         this._parentInterface.saveProgress();
     }
@@ -158,14 +171,8 @@ class SidebarReaderManager extends BasicReaderManager{
     prepareReaderEdit() {
         this._readerSync.sendEditRequest(this.#favIcon);
     }
-
-    canBeUpdatedWith(readerObjectLike) {
-        const tempReader = new ReaderData(readerObjectLike);
-        return this.parentInterface.canWeUpdateReaderWith(this._readerData, tempReader);
-    }
     
     editReader(readerObjectLike) {
-        // TODO: verify continued compatibility with exising readers first
         super.editReader(readerObjectLike);
         this.#schedule.updateRuleset(this._readerData.getSchedule());
         this.#updateReaderVisuals();

--- a/scripts/shared/reader_manager.js
+++ b/scripts/shared/reader_manager.js
@@ -158,6 +158,11 @@ class SidebarReaderManager extends BasicReaderManager{
     prepareReaderEdit() {
         this._readerSync.sendEditRequest(this.#favIcon);
     }
+
+    canBeUpdatedWith(readerObjectLike) {
+        const tempReader = new ReaderData(readerObjectLike);
+        return this.parentInterface.canWeUpdateReaderWith(this._readerData, tempReader);
+    }
     
     editReader(readerObjectLike) {
         // TODO: verify continued compatibility with exising readers first
@@ -240,6 +245,10 @@ class ReaderManagerDummy {
         return false;
     }
     
+    canWeUpdateReaderWith() {
+        return false;
+    }
+
     prepareReaderEdit() {}
     
     pinBookmark(bookmark) {

--- a/scripts/shared/reader_sync.js
+++ b/scripts/shared/reader_sync.js
@@ -100,8 +100,11 @@ class ReaderSyncCore extends ReaderSync {
             this.#deleteRequestHandler(readerObjectLike.deleteMe);
             return;
         }
-        // TODO: verify edit with WebReader interface in Core
-        //       This is solely important for the webpage recognition mechanism
+        if (!this.#readerManager.canBeUpdatedWith(readerObjectLike)) {
+            console.log("Conflict detected, will not update ");
+            // TODO: notify editor of failure
+            return;
+        }
         this.#readerManager.editReader(readerObjectLike);
         this.port.sendMessage({editCommand: readerObjectLike});
     }

--- a/scripts/shared/site_recognition.js
+++ b/scripts/shared/site_recognition.js
@@ -135,6 +135,13 @@ class SiteRecognitionInterface {
         this.#siteRecognition = siteRecognition;
     }
 
+    canCoexistWith(otherSiteRecognitionInterface) {
+        if (!(otherSiteRecognitionInterface instanceof SiteRecognitionInterface)) {
+            return false;
+        }
+        return !this.#siteRecognition.overlapsWith(otherSiteRecognitionInterface.#siteRecognition);
+    }
+
     getUrlRemainder(url, title = "") {
         return this.#siteRecognition.getUrlRemainder(url, title);
     }

--- a/scripts/shared/web_reader.js
+++ b/scripts/shared/web_reader.js
@@ -345,7 +345,7 @@ class WebReaderSidebar extends WebReader {
     }
 
     setFavIconFromKey(key, value) {
-        let managerList = this._readerStorage.getHostListFromKey(key);
+        let managerList = this._readerStorage.getCargoListForHost(key);
         for (const manager of managerList) {
             manager.updateFavIcon(value);
         }

--- a/scripts/shared/web_reader.js
+++ b/scripts/shared/web_reader.js
@@ -175,6 +175,15 @@ class WebReaderBackground extends WebReader {
         await this.#favIconController.initialize(this._readerStorage.keys());
     }
 
+    canReaderBeUpdatedWith(readerData, newReaderData) {
+        const conflicts = this._readerStorage.findConflictsWith(newReaderData);
+        if (conflicts.length == 0)
+            return true;
+        if (conflicts.length == 1 && conflicts.includes(readerData))
+            return true;
+        return false;
+    }
+
     async updateBookmark(data, doClean = true) {
         let wasValid = this._currentReader.isValid();
         let bookmarkIsNew = super.updateBookmark(data);
@@ -393,6 +402,10 @@ class WebReaderInterface {
     
     removeReader(prefixMask) {
         this.#webReader.removeReader(prefixMask);
+    }
+
+    canWeUpdateReaderWith(readerData, newReaderData) {
+        return this.#webReader.canReaderBeUpdatedWith(readerData, newReaderData);
     }
     
     relistViewerDisplay() {

--- a/spec/shared/HtmlContainerSpec.js
+++ b/spec/shared/HtmlContainerSpec.js
@@ -34,8 +34,8 @@ describe("HtmlContainer", function() {
 
         storage.saveObject(object);
         expect(storage.getObject(url)).toBe(object);
-        expect(storage.getHostListFromUrl(url)).toEqual([object]);
-        expect(storage.getHostListFromKey("www.test.com")).toEqual([object]);
+        expect(storage.getCargoListForUrl(url)).toEqual([object]);
+        expect(storage.getCargoListForHost("www.test.com")).toEqual([object]);
         expect(storage.keys()).toEqual(["www.test.com"]); 
         expect(storage.getList()).toEqual([object]);
     });
@@ -57,12 +57,12 @@ describe("HtmlContainer", function() {
         expect(storage.getObject(url2)).toBe(object2);
         expect(storage.getObject(url3)).toBe(object3);
 
-        expect(storage.getHostListFromUrl(url1)).toEqual([object1, object2]);
-        expect(storage.getHostListFromUrl(url2)).toEqual([object1, object2]);
-        expect(storage.getHostListFromUrl(url3)).toEqual([object3]);
+        expect(storage.getCargoListForUrl(url1)).toEqual([object1, object2]);
+        expect(storage.getCargoListForUrl(url2)).toEqual([object1, object2]);
+        expect(storage.getCargoListForUrl(url3)).toEqual([object3]);
 
-        expect(storage.getHostListFromKey("www.test.com")).toEqual([object1, object2]);
-        expect(storage.getHostListFromKey("www.test2.com")).toEqual([object3]);
+        expect(storage.getCargoListForHost("www.test.com")).toEqual([object1, object2]);
+        expect(storage.getCargoListForHost("www.test2.com")).toEqual([object3]);
 
         expect(storage.keys()).toEqual(["www.test.com", "www.test2.com"]); 
         expect(storage.getList()).toEqual([object1, object2, object3]);
@@ -83,8 +83,8 @@ describe("HtmlContainer", function() {
         storage.saveObject(object);
         expect(storage.getObject(url1)).toBe(object);
         expect(storage.getObject(url2)).toBe(object);
-        expect(storage.getHostListFromUrl(url1)).toEqual([object]);
-        expect(storage.getHostListFromKey("www.test.com")).toEqual([object]);
+        expect(storage.getCargoListForUrl(url1)).toEqual([object]);
+        expect(storage.getCargoListForHost("www.test.com")).toEqual([object]);
         expect(storage.keys()).toEqual(["www.test.com", "www.test2.com"]); 
         expect(storage.getList()).toEqual([object]);
     });

--- a/spec/shared/HtmlContainerSpec.js
+++ b/spec/shared/HtmlContainerSpec.js
@@ -32,7 +32,7 @@ describe("HtmlContainer", function() {
         let url = "http://www.test.com/123";
         let object = new MinimalObject(url);
 
-        storage.saveObject(object);
+        storage.saveObject(object, object.getPrefixMasks());
         expect(storage.getObject(url)).toBe(object);
         expect(storage.getCargoListForUrl(url)).toEqual([object]);
         expect(storage.getCargoListForHost("www.test.com")).toEqual([object]);
@@ -49,9 +49,9 @@ describe("HtmlContainer", function() {
         let object2 = new MinimalObject(url2);
         let object3 = new MinimalObject(url3);
 
-        storage.saveObject(object1);
-        storage.saveObject(object2);
-        storage.saveObject(object3);
+        storage.saveObject(object1, object1.getPrefixMasks());
+        storage.saveObject(object2, object2.getPrefixMasks());
+        storage.saveObject(object3, object3.getPrefixMasks());
         
         expect(storage.getObject(url1)).toBe(object1);
         expect(storage.getObject(url2)).toBe(object2);
@@ -80,7 +80,7 @@ describe("HtmlContainer", function() {
         let url2 = "http://www.test2.com/456";
         let object = new MinimalObject([url1, url2]);
 
-        storage.saveObject(object);
+        storage.saveObject(object, object.getPrefixMasks());
         expect(storage.getObject(url1)).toBe(object);
         expect(storage.getObject(url2)).toBe(object);
         expect(storage.getCargoListForUrl(url1)).toEqual([object]);


### PR DESCRIPTION
* get rid of "getPrefixMasks()" in HtmlContainer
* implement check before editing readerData
   -> turns out, this check is best done outside HtmlContainer
* No longer check for duplicates using "Set()"